### PR TITLE
feat: Adding markdown processing to articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 	"dependencies": {
 		"history": "^4.10.1",
 		"preact": "^10.1.0",
-		"preact-router": "^3.1.0"
+		"preact-router": "^3.1.0",
+		"snarkdown": "^2.0.0"
 	},
 	"devDependencies": {
 		"@types/enzyme": "^3.10.3",

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -5,6 +5,7 @@ import ArticleMeta from '../components/ArticleMeta';
 import ArticleCommentCard from '../components/ArticleCommentCard';
 import { useRootState } from '../store';
 import { DEFAULT_AVATAR } from '../store/constants';
+import snarkdown from 'snarkdown';
 
 interface ArticlePageProps {
 	slug: string;
@@ -60,7 +61,9 @@ export default function ArticlePage(props: ArticlePageProps) {
 
 			<div class="container page">
 				<div class="row article-content">
-					<div class="col-xs-12">{article.body}</div>
+					{article.body && (
+						<div class="col-xs-12" dangerouslySetInnerHTML={{ __html: snarkdown(article.body) }} />
+					)}
 				</div>
 
 				<hr />


### PR DESCRIPTION
The spec states that articles can be written in markdown, so this adds a super tiny markdown parser. 

Repo: https://github.com/developit/snarkdown
Bundlephobia: https://bundlephobia.com/result?p=snarkdown@2.0.0 - 1.1kb gzipped

Now, this parser does not provide any sanitation, however, other Real World front ends use other parsers that also don't provide sanitation. Not great, but we're no worse than anyone else. Might be worth looking at some point?