### PR TITLE
fix: Bad default meant unauthed users always triggered a 401 on the home page

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,7 +13,7 @@ export default function Home() {
 	const [articles, setArticles] = useState<Article[]>([]);
 	const [articlesCount, setArticlesCount] = useState(0);
 	const [page, setPage] = useState(1);
-	const [currentActiveTab, setCurrentActiveTab] = useState('personal');
+	const [currentActiveTab, setCurrentActiveTab] = useState('');
 	const [tag, setTag] = useState('');
 
 	const setArticle = (articleIndex: number, article: Article) => {


### PR DESCRIPTION
I had the home page default to `personal` which meant unauthed users always triggered a 401 as only logged in users have a feed.

There's a lot of edge cases for this particular bit and this exposes other problems but always triggering a 401 is probably worse.

Need to set aside a block of time to figure out how to handle this area better.