### PR TITLE
refactor: Simplifying article meta component

### DIFF
--- a/src/components/ArticleMeta.tsx
+++ b/src/components/ArticleMeta.tsx
@@ -1,19 +1,20 @@
 import { Fragment, h } from 'preact';
+import { useState } from 'preact/hooks';
 import { route } from 'preact-router';
 
 import { apiDeleteArticle, apiFavoriteArticle, apiUnfavoriteArticle } from '../services/api/article';
 import { apiFollowProfile, apiUnfollowProfile } from '../services/api/profile';
+import useStore from '../store';
 import { dateFormatter } from '../utils/dateFormatter';
 import { DEFAULT_AVATAR } from '../utils/constants';
 
 interface ArticleMetaProps {
 	article: Article;
-	setArticle: (article: Article) => void;
-	isAuthor: boolean;
 }
 
 export default function ArticleMeta(props: ArticleMetaProps) {
-	const { article, setArticle } = props;
+	const [article, setArticle] = useState(props.article);
+	const user = useStore(state => state.user);
 
 	const onDelete = async () => {
 		await apiDeleteArticle(article.slug);
@@ -27,9 +28,8 @@ export default function ArticleMeta(props: ArticleMetaProps) {
 		setArticle({ ...article, author });
 	};
 
-	const onFavorite = async () => {
+	const onFavorite = async () =>
 		setArticle(article.favorited ? await apiUnfavoriteArticle(article.slug) : await apiFavoriteArticle(article.slug));
-	};
 
 	return (
 		<div class="article-meta">
@@ -42,13 +42,12 @@ export default function ArticleMeta(props: ArticleMetaProps) {
 				</a>
 				<span class="date">{dateFormatter(article.createdAt)}</span>
 			</div>
-			{props.isAuthor ? (
+			{user?.username === article.author.username ? (
 				<Fragment>
 					<a class="btn btn-sm btn-outline-secondary" href={`/editor/${article.slug}`}>
 						<i class="ion-edit" /> Edit Article
 					</a>
 					&nbsp;&nbsp;
-					{/* TODO: Implement delete */}
 					<button class="btn btn-sm btn-outline-danger" onClick={onDelete}>
 						<i class="ion-trash-a" /> Delete Article
 					</button>

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -14,7 +14,7 @@ interface ArticlePageProps {
 }
 
 export default function ArticlePage(props: ArticlePageProps) {
-	const [article, setArticle] = useState({ author: {} } as Article);
+	const [article, setArticle] = useState<Article | undefined>(undefined);
 	const [comments, setComments] = useState<ArticleComment[]>([]);
 	const [commentBody, setCommentBody] = useState('');
 	const user = useStore(state => state.user);
@@ -37,34 +37,24 @@ export default function ArticlePage(props: ArticlePageProps) {
 		})();
 	}, [props.slug]);
 
-	return (
+	return !article ? null : (
 		<div class="article-page">
 			<div class="banner">
 				<div class="container">
 					<h1>{article.title}</h1>
-					<ArticleMeta
-						article={article}
-						setArticle={setArticle}
-						isAuthor={user?.username === article.author.username}
-					/>
+					<ArticleMeta article={article} />
 				</div>
 			</div>
 
 			<div class="container page">
 				<div class="row article-content">
-					{article.body && (
-						<div class="col-xs-12" dangerouslySetInnerHTML={{ __html: snarkdown(article.body) }} />
-					)}
+					<div class="col-xs-12" dangerouslySetInnerHTML={{ __html: snarkdown(article.body) }} />
 				</div>
 
 				<hr />
 
 				<div class="article-actions">
-					<ArticleMeta
-						article={article}
-						setArticle={setArticle}
-						isAuthor={user?.username === article.author.username}
-					/>
+					<ArticleMeta article={article} />
 				</div>
 
 				<div class="row">


### PR DESCRIPTION
Simplifies by moving state into the component and reducing the number of props needed. It can handle that itself just fine.