### PR TITLE
chore: Optimizing jest commands for their environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: lint and tests
       run: |
         yarn lint
-        yarn test --coverage
+        yarn test:ci --coverage
 
     - name: collect coverage
       uses: coverallsapp/github-action@v1.0.1

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 		"start": "webpack-dev-server",
 		"build": "cross-env NODE_ENV=production webpack",
 		"lint": "eslint '{src,test}/**/*.{ts,tsx}' --fix && prettier '{src,test}/**/*{ts,tsx}' --write",
-		"test": "cross-env TZ=America/New_York jest",
+		"test": "cross-env TZ=America/New_York jest --maxWorkers=50%",
+		"test:ci": "cross-env TZ=America/New_York jest --runInBand",
 		"analyzer": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json dist -s gzip"
 	},
 	"dependencies": {


### PR DESCRIPTION
Came across this article the other day and seems to be true: https://dev.to/vantanev/make-your-jest-tests-up-to-20-faster-by-changing-a-single-setting-i36

I certainly get a bit of a speed up locally when running the tests, and this should be better for the CI as well. Of course, we're talking about a second or two saved in all likelihood, but still nice to have.