### PR TITLE
feat: Adding loading indicators to a handful of operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
 		"rules": {
 			"@typescript-eslint/explicit-module-boundary-types": "off",
 			"@typescript-eslint/no-explicit-any": "off",
-			"@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "^_.*" }]
+			"@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "^_.*" }],
+			"react/no-danger": "off"
 		}
 	},
 	"prettier": {

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,51 @@
 		/>
 		<!-- Import the custom Bootstrap 4 theme from our hosted CDN -->
 		<link rel="stylesheet" href="//demo.productionready.io/main.css" />
+		<style>
+			#loading-spinner {
+				animation: 2s linear infinite svg-animation;
+			}
+
+			@keyframes svg-animation {
+				0% {
+					transform: rotateZ(0deg);
+				}
+				100% {
+					transform: rotateZ(360deg);
+				}
+			}
+
+			#circle {
+				animation: 1.4s ease-in-out infinite both circle-animation;
+				display: block;
+				fill: transparent;
+				stroke: #2f3d4c;
+				stroke-linecap: round;
+				stroke-dasharray: 283;
+				stroke-dashoffset: 280;
+				stroke-width: 10px;
+				transform-origin: 50% 50%;
+			}
+
+			@keyframes circle-animation {
+				0%,
+				25% {
+					stroke-dashoffset: 280;
+					transform: rotate(0);
+				}
+
+				50%,
+				75% {
+					stroke-dashoffset: 75;
+					transform: rotate(45deg);
+				}
+
+				100% {
+					stroke-dashoffset: 280;
+					transform: rotate(360deg);
+				}
+			}
+		</style>
 	</head>
 	<body>
 		<div id="app"></div>

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,0 +1,22 @@
+import { h } from 'preact';
+
+interface LoadingIndicatorProps {
+	show: boolean;
+	style?: Record<string, string>;
+	strokeColor?: string;
+	width?: string;
+}
+
+export default function LoadingIndicator(props: LoadingIndicatorProps) {
+	return (
+		<svg
+			id="loading-spinner"
+			style={{ ...props.style, display: props.show ? props.style?.display : 'none' }}
+			viewBox="0 0 100 100"
+			xmlns="http://www.w3.org/2000/svg"
+			width={props.width}
+		>
+			<circle id="circle" cx="50" cy="50" r="45" style={{ stroke: props.strokeColor }} />
+		</svg>
+	)
+}

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -4,6 +4,7 @@ import snarkdown from 'snarkdown';
 
 import ArticleMeta from '../components/ArticleMeta';
 import ArticleCommentCard from '../components/ArticleCommentCard';
+import LoadingIndicator from '../components/LoadingIndicator';
 import { apiGetArticle } from '../services/api/article';
 import { apiCreateComment, apiGetComments } from '../services/api/comments';
 import useStore from '../store';
@@ -17,6 +18,7 @@ export default function ArticlePage(props: ArticlePageProps) {
 	const [article, setArticle] = useState<Article | undefined>(undefined);
 	const [comments, setComments] = useState<ArticleComment[]>([]);
 	const [commentBody, setCommentBody] = useState('');
+	const [isLoading, setIsLoading] = useState(false);
 	const user = useStore(state => state.user);
 
 	const onPostComment = async () => {
@@ -27,12 +29,16 @@ export default function ArticlePage(props: ArticlePageProps) {
 
 	useEffect(() => {
 		(async function () {
+			setIsLoading(true);
 			setArticle(await apiGetArticle(props.slug));
 			setComments(await apiGetComments(props.slug));
+			setIsLoading(false);
 		})();
 	}, [props.slug]);
 
-	return !article ? null : (
+	return !article ? (
+		<LoadingIndicator show={isLoading} style={{ margin: '1rem auto', display: 'flex' }} width="2rem" />
+	) : (
 		<div class="article-page">
 			<div class="banner">
 				<div class="container">

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,8 +1,9 @@
 import { h } from 'preact';
-import { useEffect, useRef, useReducer } from 'preact/hooks';
+import { useEffect, useReducer, useRef, useState } from 'preact/hooks';
 import { Link } from 'preact-router';
 
 import AuthErrorHandler from '../components/AuthErrorHandler';
+import LoadingIndicator from '../components/LoadingIndicator';
 import useStore from '../store';
 
 const UPDATE_INPUT = (_state: string, e: Event) => (e.target as HTMLInputElement).value;
@@ -18,10 +19,12 @@ export default function AuthPage({ isRegister }: { isRegister?: boolean }) {
 	const [username, setUsername] = useReducer(UPDATE_INPUT, '');
 	const [email, setEmail] = useReducer(UPDATE_INPUT, '');
 	const [password, setPassword] = useReducer(UPDATE_INPUT, '');
+	const [inProgress, setInProgress] = useState(false);
 
 	const submit = async (e: Event) => {
 		e.preventDefault();
 		if (!formRef.current?.checkValidity()) return;
+		setInProgress(true);
 		isRegister ? await register({ username, email, password }) : await login({ email, password });
 	};
 
@@ -88,6 +91,7 @@ export default function AuthPage({ isRegister }: { isRegister?: boolean }) {
 								disabled={(isRegister && !username) || !email || !password}
 							>
 								{isRegister ? 'Sign up' : 'Sign in'}
+								<LoadingIndicator show={inProgress} style={{ marginLeft: '0.5rem' }} strokeColor="#fff" width="1rem" />
 							</button>
 						</form>
 					</div>

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { route } from 'preact-router';
 
+import LoadingIndicator from '../components/LoadingIndicator';
 import { apiCreateArticle, apiGetArticle, apiUpdateArticle } from '../services/api/article';
 
 interface EditorProps {
@@ -22,10 +23,12 @@ export default function Editor(props: EditorProps) {
 		body: '',
 		tagList: []
 	});
+	const [inProgress, setInProgress] = useState(false);
 
 	async function onSubmit(e: Event) {
 		e.preventDefault();
 
+		setInProgress(true);
 		const article = props.slug ? await apiUpdateArticle(props.slug, form) : await apiCreateArticle(form);
 		route(`/article/${article.slug}`);
 	}
@@ -98,6 +101,12 @@ export default function Editor(props: EditorProps) {
 									disabled={!(form.title && form.description && form.body)}
 								>
 									Publish Article
+									<LoadingIndicator
+										show={inProgress}
+										style={{ marginLeft: '0.5rem' }}
+										strokeColor="#fff"
+										width="1rem"
+									/>
 								</button>
 							</fieldset>
 						</form>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { useEffect, useLayoutEffect, useState } from 'preact/hooks';
 
 import ArticlePreview from '../components/ArticlePreview';
+import LoadingIndicator from '../components/LoadingIndicator';
 import Pagination from '../components/Pagination';
 import PopularTags from '../components/PopularTags';
 import { apiGetArticles, apiGetFeed } from '../services/api/article';
@@ -15,6 +16,7 @@ export default function Home() {
 	const [page, setPage] = useState(1);
 	const [currentActiveTab, setCurrentActiveTab] = useState('');
 	const [tag, setTag] = useState('');
+	const [isLoading, setIsLoading] = useState(false);
 
 	useLayoutEffect(() => {
 		setCurrentActiveTab(isAuthenticated ? 'personal' : 'global');
@@ -28,6 +30,7 @@ export default function Home() {
 	// 'personal'. This can lead to a flash of content.
 	useEffect(() => {
 		(async function fetchFeeds() {
+			setIsLoading(true);
 			let articles: Article[] = [];
 			let articlesCount = 0;
 			switch (currentActiveTab) {
@@ -40,6 +43,7 @@ export default function Home() {
 			}
 			setArticles(articles);
 			setArticlesCount(articlesCount);
+			setIsLoading(false);
 		})();
 	}, [currentActiveTab, page, tag]);
 
@@ -89,13 +93,10 @@ export default function Home() {
 							</ul>
 						</div>
 
-						{articles.length > 0 ? (
-							articles.map((article) => (
-								<ArticlePreview
-									key={article.slug}
-									article={article}
-								/>
-							))
+						{isLoading ? (
+							<LoadingIndicator show={isLoading} style={{ margin: '1rem auto', display: 'flex' }} width="2rem" />
+						) : articles.length > 0 ? (
+							articles.map(article => <ArticlePreview key={article.slug} article={article} />)
 						) : (
 							<div class="article-preview">No articles are here... yet.</div>
 						)}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -4,6 +4,7 @@ import { getCurrentUrl } from 'preact-router';
 import { Link } from 'preact-router/match';
 
 import ArticlePreview from '../components/ArticlePreview';
+import LoadingIndicator from '../components/LoadingIndicator';
 import Pagination from '../components/Pagination';
 import { apiGetArticles } from '../services/api/article';
 import { apiFollowProfile, apiUnfollowProfile, apiGetProfile } from '../services/api/profile';
@@ -21,6 +22,7 @@ export default function Profile(props: ProfileProps) {
 	const [articles, setArticles] = useState<Article[]>([]);
 	const [articlesCount, setArticlesCount] = useState(0);
 	const [page, setPage] = useState(1);
+	const [isLoading, setIsLoading] = useState(false);
 
 	const onFollowUser = async () => {
 		if (user.following) {
@@ -40,12 +42,14 @@ export default function Profile(props: ProfileProps) {
 
 	useEffect(() => {
 		(async function fetchArticles() {
+			setIsLoading(true);
 			const { articles, articlesCount } = await apiGetArticles(page, {
 				[/.*\/favorites/g.test(currentUrl) ? 'favorited' : 'author']: username
 			});
 
 			setArticles(articles);
 			setArticlesCount(articlesCount);
+			setIsLoading(false);
 		})();
 	}, [currentUrl, page, username]);
 
@@ -93,13 +97,14 @@ export default function Profile(props: ProfileProps) {
 							</ul>
 						</div>
 
-						{articles.length > 0 ? (
-							articles.map((article) => (
-								<ArticlePreview
-									key={article.slug}
-									article={article}
-								/>
-							))
+						{isLoading ? (
+							<LoadingIndicator
+								show={isLoading}
+								style={{ margin: '1rem auto', display: 'flex' }}
+								width="2rem"
+							/>
+						) : articles.length > 0 ? (
+							articles.map(article => <ArticlePreview key={article.slug} article={article} />)
 						) : (
 							<div class="article-preview">No articles are here... yet.</div>
 						)}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,8 @@
 import { h } from 'preact';
 import { useEffect, useState, useRef } from 'preact/hooks';
 
-import AuthErrorHandler from '../components/AuthErrorHandler'
+import AuthErrorHandler from '../components/AuthErrorHandler';
+import LoadingIndicator from '../components/LoadingIndicator';
 import useStore from '../store';
 
 export default function Settings() {
@@ -22,14 +23,16 @@ export default function Settings() {
 		email: '',
 		password: ''
 	});
+	const [inProgress, setInProgress] = useState(false);
 
 	const onSubmit = async (e: Event) => {
 		e.preventDefault();
 		if (!formRef.current?.checkValidity()) return;
 		// filter empty fields from form
 		const filteredForm = Object.entries(form).reduce((a, [k, v]) => (v == null ? a : { ...a, [k]: v }), {});
+		setInProgress(true);
 		updateUserDetails(filteredForm);
-	}
+	};
 
 	useEffect(() => {
 		setForm({
@@ -37,7 +40,7 @@ export default function Settings() {
 			username: user.username,
 			bio: user.bio,
 			email: user.email,
-			password: '',
+			password: ''
 		});
 	}, [user]);
 
@@ -126,6 +129,12 @@ export default function Settings() {
 								</fieldset>
 								<button class="btn btn-lg btn-primary pull-xs-right" disabled={buttonDisabled}>
 									Update Settings
+									<LoadingIndicator
+										show={inProgress}
+										style={{ marginLeft: '0.5rem' }}
+										strokeColor="#fff"
+										width="1rem"
+									/>
 								</button>
 							</fieldset>
 						</form>
@@ -136,7 +145,7 @@ export default function Settings() {
 							Or click here to logout.
 						</button>
 					</div>
-			</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/test/pages/__snapshots__/AuthPage.spec.tsx.snap
+++ b/test/pages/__snapshots__/AuthPage.spec.tsx.snap
@@ -58,6 +58,21 @@ exports[`AuthPage renders the Login page correctly 1`] = `
               disabled=""
             >
               Sign in
+              <svg
+                id="loading-spinner"
+                style="margin-left: 0.5rem; display: none;"
+                viewBox="0 0 100 100"
+                width="1rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="50"
+                  cy="50"
+                  id="circle"
+                  r="45"
+                  style="stroke: #fff;"
+                />
+              </svg>
             </button>
           </form>
         </div>
@@ -136,6 +151,21 @@ exports[`AuthPage renders the Register page correctly 1`] = `
               disabled=""
             >
               Sign up
+              <svg
+                id="loading-spinner"
+                style="margin-left: 0.5rem; display: none;"
+                viewBox="0 0 100 100"
+                width="1rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="50"
+                  cy="50"
+                  id="circle"
+                  r="45"
+                  style="stroke: #fff;"
+                />
+              </svg>
             </button>
           </form>
         </div>


### PR DESCRIPTION
Closes #29, or at least starts to address it

I've added a loading indicator to numerous API operations, mainly the ones where the fact work being done is not obvious. 