### PR TITLE
refactor: Switching everything but routes to named exports

### DIFF
--- a/public/components/ArticleCommentCard.tsx
+++ b/public/components/ArticleCommentCard.tsx
@@ -1,5 +1,5 @@
 import { apiDeleteComment } from '../services/api/comments';
-import useStore from '../store';
+import { useStore } from '../store';
 import { DEFAULT_AVATAR } from '../utils/constants';
 import { dateFormatter } from '../utils/dateFormatter';
 
@@ -9,7 +9,7 @@ interface ArticleCommentCardProps {
 	onDelete: () => void;
 }
 
-export default function ArticleCommentCard(props: ArticleCommentCardProps) {
+export function ArticleCommentCard(props: ArticleCommentCardProps) {
 	const { comment } = props;
 	const user = useStore(state => state.user);
 

--- a/public/components/ArticleMeta.tsx
+++ b/public/components/ArticleMeta.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'preact-iso/router';
 
 import { apiDeleteArticle, apiFavoriteArticle, apiUnfavoriteArticle } from '../services/api/article';
 import { apiFollowProfile, apiUnfollowProfile } from '../services/api/profile';
-import useStore from '../store';
+import { useStore } from '../store';
 import { dateFormatter } from '../utils/dateFormatter';
 import { DEFAULT_AVATAR } from '../utils/constants';
 
@@ -11,7 +11,7 @@ interface ArticleMetaProps {
 	article: Article;
 }
 
-export default function ArticleMeta(props: ArticleMetaProps) {
+export function ArticleMeta(props: ArticleMetaProps) {
 	const [article, setArticle] = useState(props.article);
 	const user = useStore(state => state.user);
 	const location = useLocation();

--- a/public/components/ArticlePreview.tsx
+++ b/public/components/ArticlePreview.tsx
@@ -7,7 +7,7 @@ interface ArticlePreviewProps {
 	article: Article;
 }
 
-export default function ArticlePreview(props: ArticlePreviewProps) {
+export function ArticlePreview(props: ArticlePreviewProps) {
 	const [article, setArticle] = useState(props.article);
 
 	async function onFavorite() {

--- a/public/components/AuthErrorHandler.tsx
+++ b/public/components/AuthErrorHandler.tsx
@@ -1,8 +1,6 @@
-import { h } from 'preact';
+import { useStore } from '../store';
 
-import useStore from '../store';
-
-export default function AuthErrorHandler() {
+export function AuthErrorHandler() {
 	const { error } = useStore(state => ({
 		error: state.error
 	}));

--- a/public/components/Footer.tsx
+++ b/public/components/Footer.tsx
@@ -1,4 +1,4 @@
-export default function Footer() {
+export function Footer() {
 	return (
 		<footer>
 			<div class="container">

--- a/public/components/Header.tsx
+++ b/public/components/Header.tsx
@@ -1,7 +1,7 @@
-import Link from './Link';
-import useStore from '../store';
+import { Link } from './Link';
+import { useStore } from '../store';
 
-export default function Header() {
+export function Header() {
 	const { isAuthenticated, user } = useStore(state => ({
 		isAuthenticated: state.isAuthenticated,
 		user: state.user

--- a/public/components/Link.tsx
+++ b/public/components/Link.tsx
@@ -8,7 +8,7 @@ interface LinkProps {
 	matcher?: (url: string) => boolean;
 }
 
-export default function Link(props: LinkProps) {
+export function Link(props: LinkProps) {
 	const { url } = useLocation();
 
 	return (

--- a/public/components/LoadingIndicator.tsx
+++ b/public/components/LoadingIndicator.tsx
@@ -1,5 +1,3 @@
-import { h } from 'preact';
-
 interface LoadingIndicatorProps {
 	show: boolean;
 	style?: Record<string, string>;
@@ -7,7 +5,7 @@ interface LoadingIndicatorProps {
 	width?: string;
 }
 
-export default function LoadingIndicator(props: LoadingIndicatorProps) {
+export function LoadingIndicator(props: LoadingIndicatorProps) {
 	return (
 		<svg
 			id="loading-spinner"

--- a/public/components/Pagination.tsx
+++ b/public/components/Pagination.tsx
@@ -7,7 +7,7 @@ interface PaginationProps {
 	setPage: (page: number) => void;
 }
 
-export default function Pagination(props: PaginationProps) {
+export function Pagination(props: PaginationProps) {
 	const pagesCount = Math.ceil(props.count / articlePageLimit);
 	const countArray = new Array(pagesCount).fill('');
 	const isActive = (index: number) => (props.page === index + 1 ? 'active' : '');

--- a/public/components/PopularTags.tsx
+++ b/public/components/PopularTags.tsx
@@ -6,7 +6,7 @@ interface PopularTagsProps {
 	onClick: (tag: string) => void;
 }
 
-export default function PopularTags(props: PopularTagsProps) {
+export function PopularTags(props: PopularTagsProps) {
 	const [tags, setTags] = useState<string[]>([]);
 
 	useEffect(() => {

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -4,10 +4,10 @@ import hydrate from 'preact-iso/hydrate';
 import lazy, { ErrorBoundary } from 'preact-iso/lazy';
 import { LocationProvider, Route, Router, useLocation } from 'preact-iso/router';
 
-import Header from './components/Header';
-import Footer from './components/Footer';
+import { Header } from './components/Header';
+import { Footer } from './components/Footer';
 import Home from './pages/Home';
-import useStore from './store';
+import { useStore } from './store';
 
 const AuthPage = lazy(() => import('./pages/AuthPage'));
 const ArticlePage = lazy(() => import('./pages/ArticlePage'));

--- a/public/pages/ArticlePage.tsx
+++ b/public/pages/ArticlePage.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'preact/hooks';
 import snarkdown from 'snarkdown';
 
-import ArticleMeta from '../components/ArticleMeta';
-import ArticleCommentCard from '../components/ArticleCommentCard';
-import LoadingIndicator from '../components/LoadingIndicator';
+import { ArticleMeta } from '../components/ArticleMeta';
+import { ArticleCommentCard } from '../components/ArticleCommentCard';
+import { LoadingIndicator } from '../components/LoadingIndicator';
 import { apiGetArticle } from '../services/api/article';
 import { apiCreateComment, apiGetComments } from '../services/api/comments';
-import useStore from '../store';
+import { useStore } from '../store';
 import { DEFAULT_AVATAR } from '../utils/constants';
 
 interface ArticlePageProps {

--- a/public/pages/AuthPage.tsx
+++ b/public/pages/AuthPage.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useReducer, useRef, useState } from 'preact/hooks';
 
-import Link from '../components/Link';
-
-import AuthErrorHandler from '../components/AuthErrorHandler';
-import LoadingIndicator from '../components/LoadingIndicator';
-import useStore from '../store';
+import { AuthErrorHandler } from '../components/AuthErrorHandler';
+import { Link } from '../components/Link';
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { useStore } from '../store';
 
 const UPDATE_INPUT = (_state: string, e: Event) => (e.target as HTMLInputElement).value;
 

--- a/public/pages/Editor.tsx
+++ b/public/pages/Editor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 
-import LoadingIndicator from '../components/LoadingIndicator';
+import { LoadingIndicator } from '../components/LoadingIndicator';
 import { apiCreateArticle, apiGetArticle, apiUpdateArticle } from '../services/api/article';
 
 interface EditorProps {

--- a/public/pages/Home.tsx
+++ b/public/pages/Home.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useLayoutEffect, useState } from 'preact/hooks';
 
-import ArticlePreview from '../components/ArticlePreview';
-import LoadingIndicator from '../components/LoadingIndicator';
-import Pagination from '../components/Pagination';
-import PopularTags from '../components/PopularTags';
+import { ArticlePreview } from '../components/ArticlePreview';
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { Pagination } from '../components/Pagination';
+import { PopularTags } from '../components/PopularTags';
 import { apiGetArticles, apiGetFeed } from '../services/api/article';
-import useStore from '../store';
+import { useStore } from '../store';
 
 export default function Home() {
 	const isAuthenticated = useStore(state => state.isAuthenticated);

--- a/public/pages/Profile.tsx
+++ b/public/pages/Profile.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso/router';
 
-import ArticlePreview from '../components/ArticlePreview';
-import Link from '../components/Link';
-import LoadingIndicator from '../components/LoadingIndicator';
-import Pagination from '../components/Pagination';
+import { ArticlePreview } from '../components/ArticlePreview';
+import { Link } from '../components/Link';
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { Pagination } from '../components/Pagination';
 import { apiGetArticles } from '../services/api/article';
 import { apiFollowProfile, apiUnfollowProfile, apiGetProfile } from '../services/api/profile';
-import useStore from '../store';
+import { useStore } from '../store';
 import { DEFAULT_AVATAR } from '../utils/constants';
 
 interface ProfileProps {

--- a/public/pages/Settings.tsx
+++ b/public/pages/Settings.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, useRef } from 'preact/hooks';
 import { useLocation } from 'preact-iso/router';
 
-import AuthErrorHandler from '../components/AuthErrorHandler';
-import LoadingIndicator from '../components/LoadingIndicator';
-import useStore from '../store';
+import { AuthErrorHandler } from '../components/AuthErrorHandler';
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { useStore } from '../store';
 
 export default function Settings() {
 	const location = useLocation();

--- a/public/store/index.ts
+++ b/public/store/index.ts
@@ -15,7 +15,7 @@ type State = {
 	updateUserDetails: (user: Partial<Profile>) => Promise<void>;
 };
 
-const useStore = create<State>(
+export const useStore = create<State>(
 	persist(
 		set => ({
 			isAuthenticated: false,
@@ -62,5 +62,3 @@ const useStore = create<State>(
 		}
 	)
 );
-
-export default useStore;


### PR DESCRIPTION
Don't know why I didn't do this when doing the other fixes, but here we are. 

Kept the default exports on the pages, as that helps enforce a singular output like we'd want. 