### PR TITLE
fix: Data persistence rehydration bug

### DIFF
--- a/public/components/Header.tsx
+++ b/public/components/Header.tsx
@@ -2,10 +2,7 @@ import { Link } from './Link';
 import { useStore } from '../store';
 
 export function Header() {
-	const { isAuthenticated, user } = useStore(state => ({
-		isAuthenticated: state.isAuthenticated,
-		user: state.user as User
-	}));
+	const user = useStore(state => state.user);
 
 	return (
 		<nav class="navbar navbar-light">
@@ -17,7 +14,7 @@ export function Header() {
 					<li class="nav-item">
 						<Link href="/">Home</Link>
 					</li>
-					{isAuthenticated ? (
+					{user ? (
 						<>
 							<li class="nav-item">
 								<Link href="/editor">

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -47,7 +47,7 @@ export async function prerender() {
 }
 
 function AuthenticatedRoute(props: { path: string; component: (props: any) => JSX.Element | null }) {
-	const isAuthenticated = useStore(state => state.isAuthenticated);
+	const isAuthenticated = useStore(state => !!state.user);
 	const location = useLocation();
 
 	useEffect(() => {

--- a/public/pages/Home.tsx
+++ b/public/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 
 import { ArticlePreview } from '../components/ArticlePreview';
 import { LoadingIndicator } from '../components/LoadingIndicator';
@@ -8,25 +8,15 @@ import { apiGetArticles, apiGetFeed } from '../services/api/article';
 import { useStore } from '../store';
 
 export default function HomePage() {
-	const isAuthenticated = useStore(state => state.isAuthenticated);
+	const isAuthenticated = useStore(state => !!state.user);
 
 	const [articles, setArticles] = useState<Article[]>([]);
 	const [articlesCount, setArticlesCount] = useState(0);
 	const [page, setPage] = useState(1);
-	const [currentActiveTab, setCurrentActiveTab] = useState('');
+	const [currentActiveTab, setCurrentActiveTab] = useState(isAuthenticated ? 'personal' : 'global');
 	const [tag, setTag] = useState('');
 	const [isLoading, setIsLoading] = useState(false);
 
-	useLayoutEffect(() => {
-		setCurrentActiveTab(isAuthenticated ? 'personal' : 'global');
-	}, [isAuthenticated]);
-
-	// This has a problem when refreshing the page. Zustand, when restoring state
-	// from localStorage (for persistance) will assume the default value for
-	// `isAuthenticated` on the first render -- false. The layout effect will then
-	// trigger, setting the state to 'global', which causes a fetch request for global
-	// articles to occur. Zustand will then correctly hydrate, and switch back to
-	// 'personal'. This can lead to a flash of content.
 	useEffect(() => {
 		(async function fetchFeeds() {
 			setIsLoading(true);
@@ -100,7 +90,7 @@ export default function HomePage() {
 							<div class="article-preview">No articles are here... yet.</div>
 						)}
 
-						<Pagination count={articlesCount} page={page} setPage={setPage} />
+						{!isLoading && <Pagination count={articlesCount} page={page} setPage={setPage} />}
 					</div>
 
 					<div class="col-md-3">

--- a/public/store/index.ts
+++ b/public/store/index.ts
@@ -1,11 +1,9 @@
 import create from 'zustand';
-import { persist } from 'zustand/middleware';
 import { authStorageService } from 'ts-api-toolkit';
 
 import { apiRegister, apiLogin, apiUpdateProfile } from '../services/api/auth';
 
 type State = {
-	isAuthenticated: boolean;
 	user?: User;
 	error: { [key: string]: string[] };
 	login: (user: LoginUser) => Promise<void>;
@@ -15,50 +13,55 @@ type State = {
 	updateUserDetails: (user: Partial<Profile>) => Promise<void>;
 };
 
-export const useStore = create<State>(
-	persist(
-		set => ({
-			isAuthenticated: false,
-			error: {},
-			login: async user => {
-				set({ error: {} });
-				try {
-					const userData = await apiLogin(user);
-					authStorageService.saveToken(userData.token);
-					set({ isAuthenticated: true, user: userData });
-				} catch (error) {
-					set({ error });
-				}
-			},
-			logout: () => {
-				set({ error: {} });
-				authStorageService.destroyToken();
-				set({ isAuthenticated: false, user: undefined });
-			},
-			register: async user => {
-				set({ error: {} });
-				try {
-					const userData = await apiRegister(user);
-					authStorageService.saveToken(userData.token);
-					set({ isAuthenticated: true, user: userData });
-				} catch (error) {
-					set({ error });
-				}
-			},
-			resetErrors: () => set({ error: {} }),
-			updateUserDetails: async updatedUser => {
-				set({ error: {} });
-				try {
-					const userData = await apiUpdateProfile(updatedUser);
-					authStorageService.saveToken(userData.token);
-					set({ user: userData });
-				} catch (error) {
-					set({ error });
-				}
-			}
-		}),
-		{
-			name: 'user-storage'
+const writeUserToStorage = (user: User) => localStorage.setItem('user', JSON.stringify(user));
+const removeUserFromStorage = () => localStorage.removeItem('user');
+
+export const useStore = create<State>(set => ({
+	// Properly handling this takes way more effort than it's ever worth.
+	// Passing `null` to `JSON.parse()` is ultimately fine, even if it
+	// expects a string with strict TS.
+	//
+	// eslint-disable-next-line
+	// @ts-ignore
+	user: JSON.parse(localStorage.getItem('user')) || undefined,
+	error: {},
+	login: async user => {
+		set({ error: {} });
+		try {
+			const userData = await apiLogin(user);
+			writeUserToStorage(userData);
+			authStorageService.saveToken(userData.token);
+			set({ user: userData });
+		} catch (error) {
+			set({ error });
 		}
-	)
-);
+	},
+	logout: () => {
+		set({ error: {} });
+		authStorageService.destroyToken();
+		removeUserFromStorage();
+		set({ user: undefined });
+	},
+	register: async user => {
+		set({ error: {} });
+		try {
+			const userData = await apiRegister(user);
+			writeUserToStorage(userData);
+			authStorageService.saveToken(userData.token);
+			set({ user: userData });
+		} catch (error) {
+			set({ error });
+		}
+	},
+	resetErrors: () => set({ error: {} }),
+	updateUserDetails: async updatedUser => {
+		set({ error: {} });
+		try {
+			const userData = await apiUpdateProfile(updatedUser);
+			writeUserToStorage(userData);
+			set({ user: userData });
+		} catch (error) {
+			set({ error });
+		}
+	}
+}));

--- a/public/store/index.ts
+++ b/public/store/index.ts
@@ -13,6 +13,8 @@ type State = {
 	updateUserDetails: (user: Partial<Profile>) => Promise<void>;
 };
 
+const isBrowser = typeof window !== 'undefined';
+
 const writeUserToStorage = (user: User) => localStorage.setItem('user', JSON.stringify(user));
 const removeUserFromStorage = () => localStorage.removeItem('user');
 
@@ -23,7 +25,7 @@ export const useStore = create<State>(set => ({
 	//
 	// eslint-disable-next-line
 	// @ts-ignore
-	user: JSON.parse(localStorage.getItem('user')) || undefined,
+	user: JSON.parse(isBrowser && localStorage.getItem('user')) || undefined,
 	error: {},
 	login: async user => {
 		set({ error: {} });


### PR DESCRIPTION
Zustand's persistence is restored asynchronously, which is an issue on the home page as the logged in status for the user dictates which feed, personal or global, is retrieved.While we could wait for Zustand to retrieve that user data, that would mean handling / delaying that feed retrieval for a procedure (`localStorage.getItem(...)`) that can be done synchronously.

Also saves ~1.66kb